### PR TITLE
add TDI-2 support

### DIFF
--- a/BBHX_PhenomD.py
+++ b/BBHX_PhenomD.py
@@ -2,7 +2,7 @@ import functools
 import math
 import numpy as np
 from scipy.interpolate import interp1d
-from bbhx.utils.constants import MTSUN_SI, YRSID_SI
+from bbhx.utils.constants import MTSUN_SI, YRSID_SI, L_SI
 from bbhx.waveformbuild import BBHWaveformFD
 from pycbc.coordinates import TIME_OFFSET_20_DEGREES, lisa_to_ssb, ssb_to_lisa
 
@@ -214,9 +214,9 @@ def bbhx_fd(ifos=None, run_phenomd=True, tdi=None,
         from pycbc.psd.analytical_space import omega_length
         if sample_points is None:
             # assume all channels share the same sample_frequencies
-            omega_len = omega_length(f=output[channel].sample_frequencies, len_arm=2.5e9)
+            omega_len = omega_length(f=output[channel].sample_frequencies, len_arm=L_SI)
         else:
-            omega_len = omega_length(f=sample_points, len_arm=2.5e9)
+            omega_len = omega_length(f=sample_points, len_arm=L_SI)
         rescale = 2j*np.sin(2*omega_len)*np.exp(-2j*omega_len)
         for key in output:
             output[key] *= rescale

--- a/BBHX_PhenomD.py
+++ b/BBHX_PhenomD.py
@@ -218,8 +218,8 @@ def bbhx_fd(ifos=None, run_phenomd=True, tdi='1.5',
         else:
             omega_len = omega_length(f=sample_points, len_arm=2.5e9)
         rescale = 2j*np.sin(2*omega_len)*np.exp(-2j*omega_len)
-        for tdi_wave in output:
-            tdi_wave *= rescale
+        for key in output:
+            output[key] *= rescale
     elif tdi == '1.5':
         pass
     else:

--- a/BBHX_PhenomD.py
+++ b/BBHX_PhenomD.py
@@ -55,7 +55,7 @@ def interpolated_tf(m1, m2):
     tf_track = interp1d(t_array, freq_array)
     return tf_track
 
-def bbhx_fd(ifos=None, run_phenomd=True, tdi='1.5',
+def bbhx_fd(ifos=None, run_phenomd=True, tdi=None,
             ref_frame='LISA', sample_points=None, **params):
 
     if ifos is None:
@@ -223,6 +223,6 @@ def bbhx_fd(ifos=None, run_phenomd=True, tdi='1.5',
     elif str(tdi) == '1.5':
         pass
     else:
-        raise Exception("Only support TDI-1.5 and TDI-2.0 for now.")
+        raise Exception("The TDI version only supports '1.5' and '2.0' for now.")
 
     return output

--- a/BBHX_PhenomD.py
+++ b/BBHX_PhenomD.py
@@ -55,7 +55,7 @@ def interpolated_tf(m1, m2):
     tf_track = interp1d(t_array, freq_array)
     return tf_track
 
-def bbhx_fd(ifos=None, run_phenomd=True,
+def bbhx_fd(ifos=None, run_phenomd=True, tdi='1.5',
             ref_frame='LISA', sample_points=None, **params):
 
     if ifos is None:
@@ -208,5 +208,21 @@ def bbhx_fd(ifos=None, run_phenomd=True,
             if t_offset != 0:
                 # subtract t_offset from FD waveform
                 output[channel] *= np.exp(2j*np.pi*sample_points*t_offset)
+
+    # convert TDI version
+    if tdi == '2.0':
+        from pycbc.psd.analytical_space import omega_length
+        if sample_points is None:
+            # assume all channels share the same sample_frequencies
+            omega_len = omega_length(f=output[channel].sample_frequencies, len_arm=2.5e9)
+        else:
+            omega_len = omega_length(f=sample_points, len_arm=2.5e9)
+        rescale = 2j*np.sin(2*omega_len)*np.exp(-2j*omega_len)
+        for tdi_wave in output:
+            tdi_wave *= rescale
+    elif tdi == '1.5':
+        pass
+    else:
+        raise Exception("Only support TDI-1.5 and TDI-2.0 for now.")
 
     return output

--- a/BBHX_PhenomD.py
+++ b/BBHX_PhenomD.py
@@ -220,9 +220,7 @@ def bbhx_fd(ifos=None, run_phenomd=True, tdi=None,
         rescale = 2j*np.sin(2*omega_len)*np.exp(-2j*omega_len)
         for key in output:
             output[key] *= rescale
-    elif str(tdi) == '1.5':
-        pass
-    else:
+    if str(tdi) not in ['1.5', '2.0']:
         raise ValueError("The TDI version only supports '1.5' and '2.0' for now.")
 
     return output

--- a/BBHX_PhenomD.py
+++ b/BBHX_PhenomD.py
@@ -223,6 +223,6 @@ def bbhx_fd(ifos=None, run_phenomd=True, tdi=None,
     elif str(tdi) == '1.5':
         pass
     else:
-        raise Exception("The TDI version only supports '1.5' and '2.0' for now.")
+        raise ValueError("The TDI version only supports '1.5' and '2.0' for now.")
 
     return output

--- a/BBHX_PhenomD.py
+++ b/BBHX_PhenomD.py
@@ -210,7 +210,7 @@ def bbhx_fd(ifos=None, run_phenomd=True, tdi='1.5',
                 output[channel] *= np.exp(2j*np.pi*sample_points*t_offset)
 
     # convert TDI version
-    if tdi == '2.0':
+    if str(tdi) == '2.0':
         from pycbc.psd.analytical_space import omega_length
         if sample_points is None:
             # assume all channels share the same sample_frequencies
@@ -220,7 +220,7 @@ def bbhx_fd(ifos=None, run_phenomd=True, tdi='1.5',
         rescale = 2j*np.sin(2*omega_len)*np.exp(-2j*omega_len)
         for key in output:
             output[key] *= rescale
-    elif tdi == '1.5':
+    elif str(tdi) == '1.5':
         pass
     else:
         raise Exception("Only support TDI-1.5 and TDI-2.0 for now.")

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup.py file for BBHX waveform into pycbc waveform plugin package
 from setuptools import Extension, setup, Command
 from setuptools import find_packages
 
-VERSION = '0.2'
+VERSION = '0.3'
 
 setup (
     name = 'pycbc-bbhx-plugin',

--- a/tests.py
+++ b/tests.py
@@ -4,8 +4,10 @@ import pytest
 
 
 @pytest.mark.parametrize("ref_frame", ["SSB", "LISA"])
+@pytest.mark.parametrize("tdi", ["1.5", "2.5"])
 def test_get_fd_det_waveform(ref_frame):
     params = {}
+    params["tdi"] = tdi
     params["ref_frame"] = ref_frame
     params["approximant"] = "BBHX_PhenomD"
     params["coa_phase"] = 0.0

--- a/tests.py
+++ b/tests.py
@@ -4,7 +4,7 @@ import pytest
 
 
 @pytest.mark.parametrize("ref_frame", ["SSB", "LISA"])
-@pytest.mark.parametrize("tdi", ["1.5", "2.5"])
+@pytest.mark.parametrize("tdi", ["1.5", "2.0"])
 def test_get_fd_det_waveform(tdi, ref_frame):
     params = {}
     params["tdi"] = tdi

--- a/tests.py
+++ b/tests.py
@@ -5,7 +5,7 @@ import pytest
 
 @pytest.mark.parametrize("ref_frame", ["SSB", "LISA"])
 @pytest.mark.parametrize("tdi", ["1.5", "2.5"])
-def test_get_fd_det_waveform(ref_frame):
+def test_get_fd_det_waveform(tdi, ref_frame):
     params = {}
     params["tdi"] = tdi
     params["ref_frame"] = ref_frame


### PR DESCRIPTION
@ahnitz @spxiwh This PR adds TDI-2 conversion to the BBHx waveform. Original BBHx's response is TDI-1.5, I'm using those equitations to convert TDI-1.5 to TDI-2.0:
![image](https://github.com/gwastro/BBHX-waveform-model/assets/6574526/9f8b38ad-9ad2-46b6-aac9-63cd01337eaa)
Those are for the X/Y/Z channels, but the A/E/T channels are just linear combinations of X/Y/Z, so they still follow these.
