### PR TITLE
Add support for HoM

### DIFF
--- a/BBHX_Phenom.py
+++ b/BBHX_Phenom.py
@@ -166,14 +166,13 @@ the Earth by ~20 degrees." % TIME_OFFSET_20_DEGREES)
         err_msg = f"Don't recognise reference frame {ref_frame}. "
         err_msg = f"Known frames are 'LISA' and 'SSB'."
 
-    # The mode with the largest m will have the highest frequency
-    # since approximately F_lm = m/2 * F_22 and will therefore reach this
-    # frequency at the earliest time
-    max_m_mode = max([mode[1] for mode in mode_array])
+    # The lowest m mode will have the lowest frequency at a given start time
+    # so we use this to compute the track
+    min_m_mode = max([mode[1] for mode in mode_array])
     if ('f_lower' not in params) or (params['f_lower'] < 0):
         # the default value of 'f_lower' in PyCBC is -1.
-        tf_track = interpolated_tf(m1, m2, m_mode=max_m_mode)
-        t_max = chirptime(m1=m1, m2=m2, f_lower=1e-4, m_mode=max_m_mode)
+        tf_track = interpolated_tf(m1, m2, m_mode=min_m_mode)
+        t_max = chirptime(m1=m1, m2=m2, f_lower=1e-4, m_mode=min_m_mode)
         if t_obs_start > t_max:
             # Avoid "above the interpolation range" issue.
             f_min = 1e-4
@@ -181,8 +180,8 @@ the Earth by ~20 degrees." % TIME_OFFSET_20_DEGREES)
             f_min = tf_track(t_obs_start) # in Hz
     else:
         f_min = np.float64(params['f_lower']) # in Hz
-        tf_track = interpolated_tf(m1, m2, m_mode=max_m_mode)
-        t_max = chirptime(m1=m1, m2=m2, f_lower=1e-4, m_mode=max_m_mode)
+        tf_track = interpolated_tf(m1, m2, m_mode=min_m_mode)
+        t_max = chirptime(m1=m1, m2=m2, f_lower=1e-4, m_mode=min_m_mode)
         if t_obs_start > t_max:
             f_min_tobs = 1e-4
         else:

--- a/BBHX_Phenom.py
+++ b/BBHX_Phenom.py
@@ -88,7 +88,7 @@ def interpolated_tf(m1, m2, m_mode=None):
 
 def waveform_setup(**kwargs):
     if kwargs['approximant'] == "BBHX_PhenomD":
-        if len(kwargs['mode_array']) != 1:
+        if kwargs.get('mode_array') is not None  and len(kwargs['mode_array']) != 1:
             raise RuntimeError("BBHX_PhenomD only supports the (2,2) mode!")
         kwargs['mode_array'] = [(2, 2)]
         return _bbhx_fd(run_phenomd=True, **kwargs)

--- a/BBHX_Phenom.py
+++ b/BBHX_Phenom.py
@@ -12,12 +12,10 @@ from warnings import warn
 def get_waveform_genner(log_mf_min, run_phenomd=True):
     # See below where this function is called for description of how we handle
     # log_mf_min.
-    if log_mf_min is None:
-        wave_gen = BBHWaveformFD(amp_phase_kwargs=dict(run_phenomd=run_phenomd))
-    else:
-        mf_min = math.exp(log_mf_min/25.)
-        wave_gen = BBHWaveformFD(amp_phase_kwargs=dict(run_phenomd=run_phenomd,
-                                                       mf_min=mf_min))
+    mf_min = math.exp(log_mf_min/25.)
+    wave_gen = BBHWaveformFD(
+        amp_phase_kwargs=dict(run_phenomd=run_phenomd, mf_min=mf_min),
+    )
     return wave_gen
 
 

--- a/BBHX_Phenom.py
+++ b/BBHX_Phenom.py
@@ -178,10 +178,10 @@ the Earth by ~20 degrees." % TIME_OFFSET_20_DEGREES)
     # will do the same thing.
     compress = True #  If True, combine harmonics into single channel waveforms. (Default: True)
     # Need to give length if direct = False.
-    direct = False # If True, directly compute the waveform without interpolation. (Default: False)
+    direct = True # If True, directly compute the waveform without interpolation. (Default: False)
     fill = True # See the BBHX documentation
     squeeze = True # See the BBHX documentation
-    length = 1024 * 8 # An internal generation parameter, not an output parameter
+    # length = 1024 * 8 # An internal generation parameter, not an output parameter
     shift_t_limits = False # Times are relative to merger
     t_obs_end = 0.0 # Generates ringdown as well!
 
@@ -192,10 +192,10 @@ the Earth by ~20 degrees." % TIME_OFFSET_20_DEGREES)
                     dist, phi_ref, f_ref, inc, lam,
                     beta, psi, t_ref, freqs=freqs,
                     modes=params['mode_array'], direct=direct, fill=fill,
-                    squeeze=squeeze, length=length,
+                    squeeze=squeeze, # length=length,
                     t_obs_start=t_obs_start/YRSID_SI,
                     t_obs_end=t_obs_end, compress=compress,
-                    shift_t_limits=shift_t_limits)[0]
+                    shift_t_limits=shift_t_limits)
 
     wanted = {}
 

--- a/BBHX_Phenom.py
+++ b/BBHX_Phenom.py
@@ -205,8 +205,8 @@ the Earth by ~20 degrees." % TIME_OFFSET_20_DEGREES)
         err_msg = f"Don't recognise reference frame {ref_frame}. "
         err_msg = f"Known frames are 'LISA' and 'SSB'."
 
-    # The lowest m mode will have the lowest frequency at a given start time
-    # so we use this to compute the track
+    # We follow the convention used in LAL and set the frequency based on the
+    # highest m mode. This means that lower m modes will start at later times.
     max_m_mode = max([mode[1] for mode in mode_array])
     if ('f_lower' not in params) or (params['f_lower'] < 0):
         # the default value of 'f_lower' in PyCBC is -1.

--- a/BBHX_Phenom.py
+++ b/BBHX_Phenom.py
@@ -11,9 +11,12 @@ from pycbc.coordinates import TIME_OFFSET_20_DEGREES, lisa_to_ssb, ssb_to_lisa
 def get_waveform_genner(log_mf_min, run_phenomd=True):
     # See below where this function is called for description of how we handle
     # log_mf_min.
-    mf_min = math.exp(log_mf_min/25.)
-    wave_gen = BBHWaveformFD(amp_phase_kwargs=dict(run_phenomd=run_phenomd,
-                                                   mf_min=mf_min))
+    if log_mf_min is None:
+        wave_gen = BBHWaveformFD(amp_phase_kwargs=dict(run_phenomd=run_phenomd))
+    else:
+        mf_min = math.exp(log_mf_min/25.)
+        wave_gen = BBHWaveformFD(amp_phase_kwargs=dict(run_phenomd=run_phenomd,
+                                                       mf_min=mf_min))
     return wave_gen
 
 @functools.lru_cache(maxsize=10)
@@ -70,7 +73,8 @@ def waveform_setup(**kwargs):
         return _bbhx_fd(run_phenomd=False, **kwargs)
 
 def _bbhx_fd(ifos=None, run_phenomd=True, ref_frame='LISA',
-             sample_points=None, **params):
+             sample_points=None, length=1024, direct=False,
+             min_f=False, **params):
 
     if ifos is None:
         raise Exception("Must define data streams to compute")
@@ -128,32 +132,36 @@ the Earth by ~20 degrees." % TIME_OFFSET_20_DEGREES)
         err_msg = f"Don't recognise reference frame {ref_frame}. "
         err_msg = f"Known frames are 'LISA' and 'SSB'."
 
-    if ('f_lower' not in params) or (params['f_lower'] < 0):
-        # the default value of 'f_lower' in PyCBC is -1.
-        tf_track = interpolated_tf(m1, m2)
-        t_max = chirptime(m1=m1, m2=m2, f_lower=1e-4)
-        if t_obs_start > t_max:
-            # Avoid "above the interpolation range" issue.
-            f_min = 1e-4
+    if min_f:
+        if ('f_lower' not in params) or (params['f_lower'] < 0):
+            # the default value of 'f_lower' in PyCBC is -1.
+            tf_track = interpolated_tf(m1, m2)
+            t_max = chirptime(m1=m1, m2=m2, f_lower=1e-4)
+            if t_obs_start > t_max:
+                # Avoid "above the interpolation range" issue.
+                f_min = 1e-4
+            else:
+                f_min = tf_track(t_obs_start) # in Hz
         else:
-            f_min = tf_track(t_obs_start) # in Hz
-    else:
-        f_min = np.float64(params['f_lower']) # in Hz
-        tf_track = interpolated_tf(m1, m2)
-        t_max = chirptime(m1=m1, m2=m2, f_lower=1e-4)
-        if t_obs_start > t_max:
-            f_min_tobs = 1e-4
-        else:
-            f_min_tobs = tf_track(t_obs_start) # in Hz
-        if f_min < f_min_tobs:
-            err_msg = f"Input 'f_lower' is lower than the value calculated from 't_obs_start'."
+            f_min = np.float64(params['f_lower']) # in Hz
+            tf_track = interpolated_tf(m1, m2)
+            t_max = chirptime(m1=m1, m2=m2, f_lower=1e-4)
+            if t_obs_start > t_max:
+                f_min_tobs = 1e-4
+            else:
+                f_min_tobs = tf_track(t_obs_start) # in Hz
+            if f_min < f_min_tobs:
+                err_msg = f"Input 'f_lower' is lower than the value calculated from 't_obs_start'."
 
-    # We want to cache the waveform generator, but as it takes a mass dependent
-    # start frequency as input this is hard.
-    # To solve this we *round* the *logarithm* of this mass-dependent start
-    # frequency. The factor of 25 ensures reasonable spacing while doing this.
-    # So we round down to the nearest 1/25 of the logarithm of the frequency
-    log_mf_min = int(math.log(f_min*MTSUN_SI*(m1+m2)) * 25)
+        # We want to cache the waveform generator, but as it takes a mass dependent
+        # start frequency as input this is hard.
+        # To solve this we *round* the *logarithm* of this mass-dependent start
+        # frequency. The factor of 25 ensures reasonable spacing while doing this.
+        # So we round down to the nearest 1/25 of the logarithm of the frequency
+        log_mf_min = int(math.log(f_min*MTSUN_SI*(m1+m2)) * 25)
+    else:
+        log_mf_min=None
+
     wave_gen = get_waveform_genner(log_mf_min, run_phenomd=run_phenomd)
 
     if sample_points is None:
@@ -177,25 +185,31 @@ the Earth by ~20 degrees." % TIME_OFFSET_20_DEGREES)
     # If creating injection of many modes, or just single, compress = True
     # will do the same thing.
     compress = True #  If True, combine harmonics into single channel waveforms. (Default: True)
-    # Need to give length if direct = False.
-    direct = True # If True, directly compute the waveform without interpolation. (Default: False)
     fill = True # See the BBHX documentation
     squeeze = True # See the BBHX documentation
-    # length = 1024 * 8 # An internal generation parameter, not an output parameter
     shift_t_limits = False # Times are relative to merger
     t_obs_end = 0.0 # Generates ringdown as well!
 
-
     # NOTE: This does not allow for the seperation of multiple modes into
     # their own streams. All modes requested are combined into one stream.
-    wave = wave_gen(m1, m2, a1, a2,
-                    dist, phi_ref, f_ref, inc, lam,
-                    beta, psi, t_ref, freqs=freqs,
-                    modes=params['mode_array'], direct=direct, fill=fill,
-                    squeeze=squeeze, # length=length,
-                    t_obs_start=t_obs_start/YRSID_SI,
-                    t_obs_end=t_obs_end, compress=compress,
-                    shift_t_limits=shift_t_limits)
+    if direct == 'True' or direct == True:
+        wave = wave_gen(m1, m2, a1, a2,
+                        dist, phi_ref, f_ref, inc, lam,
+                        beta, psi, t_ref, freqs=freqs,
+                        modes=params['mode_array'], direct=True, fill=fill,
+                        squeeze=squeeze, t_obs_start=t_obs_start/YRSID_SI,
+                        t_obs_end=t_obs_end, compress=compress,
+                        shift_t_limits=shift_t_limits)
+    else:
+        # Need to give length if direct = False.
+        wave = wave_gen(m1, m2, a1, a2,
+                        dist, phi_ref, f_ref, inc, lam,
+                        beta, psi, t_ref, freqs=freqs,
+                        modes=params['mode_array'], direct=direct, fill=fill,
+                        squeeze=squeeze, length=int(length),
+                        t_obs_start=t_obs_start/YRSID_SI,
+                        t_obs_end=t_obs_end, compress=compress,
+                        shift_t_limits=shift_t_limits)[0]
 
     wanted = {}
 

--- a/BBHX_Phenom.py
+++ b/BBHX_Phenom.py
@@ -71,7 +71,7 @@ def waveform_setup(**kwargs):
         return _bbhx_fd(**kwargs)
     elif kwargs['approximant'] == "BBHX_PhenomHM":
         if 'mode_array' not in kwargs:
-            raise Exception("Must define modes in mode_array")
+            kwargs['mode_array'] = [(2, 2), (2, 1), (3, 3), (3, 2), (4, 4), (4, 3)]
         return _bbhx_fd(run_phenomd=False, **kwargs)
 
 def _bbhx_fd(ifos=None, run_phenomd=True, ref_frame='LISA',

--- a/BBHX_Phenom.py
+++ b/BBHX_Phenom.py
@@ -114,6 +114,36 @@ def _bbhx_fd(
     interp_f_lower=1e-4,
     **params
 ):
+    
+    """Function to generate frequency-domain waveforms using BBHx.
+    
+    Parameters
+    ----------
+    ifos : list
+        List of interferometers
+    run_phenomd : bool
+        Flag passed to :code:`bbhx.waveformbuild.BBHWaveformFD` that determines
+        if PhenomD or PhenomHM is used.
+    ref_frame : {'LISA', 'SSB'}
+        Reference frame.
+    samples_points : numpy.ndarray, optional
+        Array of frequencies for computing the waveform
+    length : int
+        Length parameter passed to BBHx. Must be specified if
+        :code:`direct=False`. See BBHx documentation for more details.
+    direct : bool
+        See BBHx documentation.
+    num_interp : int
+        Number of interpolation points used for computing chirp time.
+    interp_f_lower : float
+        Lower frequency cutoff used for interpolation when computing the 
+        chirp time.
+    
+    Returns
+    -------
+    dict
+        A dictionary containing the the waveforms for each interferometer.
+    """
 
     if ifos is None:
         raise Exception("Must define data streams to compute")

--- a/BBHX_Phenom.py
+++ b/BBHX_Phenom.py
@@ -80,8 +80,7 @@ def interpolated_tf(m1, m2, m_mode=None):
     # the corresponding `f_min` for `t_obs_start`.
     freq_array = np.logspace(-4, 0, num=10)
     t_array = np.zeros(len(freq_array))
-    for i in range(len(freq_array)):
-        t_array[i] = chirptime(m1=m1, m2=m2, f_lower=freq_array[i], m_mode=m_mode)
+    t_array = chirptime(m1=m1, m2=m2, f_lower=freq_array, m_mode=m_mode)
     tf_track = interp1d(t_array, freq_array)
     return tf_track
 

--- a/BBHX_Phenom.py
+++ b/BBHX_Phenom.py
@@ -31,12 +31,18 @@ def imr_duration(**params):
     # including merge, ringdown, and aligned spin effects.
     # This is used in the time-domain signal injection in PyCBC.
     import warnings
-    from pycbc.waveform.waveform import imrphenomd_length_in_time
 
     nparams = {'mass1':params['mass1'], 'mass2':params['mass2'],
                'spin1z':params['spin1z'], 'spin2z':params['spin2z'],
                'f_lower':params['f_lower']}
-    time_length = np.float64(imrphenomd_length_in_time(**nparams))
+
+    if params['approximant'] == 'BBHX_IMRPhenomD':
+        from pycbc.waveform.waveform import imrphenomd_length_in_time
+        time_length = np.float64(imrphenomd_length_in_time(**nparams))
+    elif params['approximant'] == 'BBHX_IMRPhenomHM':
+        from pycbc.waveform.waveform import imrphenomhm_length_in_time
+        time_length = np.float64(imrphenomhm_length_in_time(**nparams))
+
     if time_length < 2678400:
         warnings.warn("Waveform duration is too short! Setting it to 1 month (2678400 s).")
         time_length = 2678400

--- a/BBHX_Phenom.py
+++ b/BBHX_Phenom.py
@@ -93,8 +93,8 @@ def _bbhx_fd(ifos=None, run_phenomd=True, ref_frame='LISA',
             t_offset = np.float64(params['t_offset']) # in seconds
     else:
         raise Exception("Must set `t_offset`, if you don't have a preferred value, \
-                        please set it to be the default value %f, which will put LISA behind \
-                        the Earth by ~20 degrees." % TIME_OFFSET_20_DEGREES)
+please set it to be the default value %f, which will put LISA behind \
+the Earth by ~20 degrees." % TIME_OFFSET_20_DEGREES)
     t_obs_start = np.float64(params['t_obs_start']) # in seconds
 
     if ref_frame == 'LISA':

--- a/BBHX_Phenom.py
+++ b/BBHX_Phenom.py
@@ -8,13 +8,12 @@ from pycbc.coordinates import TIME_OFFSET_20_DEGREES, lisa_to_ssb, ssb_to_lisa
 
 
 @functools.lru_cache(maxsize=128)
-def get_waveform_genner(log_mf_min, run_phenomd=True, use_gpu=False):
+def get_waveform_genner(log_mf_min, run_phenomd=True):
     # See below where this function is called for description of how we handle
     # log_mf_min.
     mf_min = math.exp(log_mf_min/25.)
     wave_gen = BBHWaveformFD(amp_phase_kwargs=dict(run_phenomd=run_phenomd,
-                                                   mf_min=mf_min),
-                             use_gpu=use_gpu)
+                                                   mf_min=mf_min))
     return wave_gen
 
 @functools.lru_cache(maxsize=10)
@@ -57,11 +56,15 @@ def interpolated_tf(m1, m2):
     tf_track = interp1d(t_array, freq_array)
     return tf_track
 
+def waveform_setup(**kwargs):
+    if kwargs['approximant'] == "BBHX_PhenomD":
+        kwargs['mode_array'] = [(2, 2)]
+        return _bbhx_fd(**kwargs)
+    elif kwargs['approximant'] == "BBHX_PhenomHM":
+        return _bbhx_fd(run_phenomd=False, **kwargs)
 
-
-# For now, always run phenom=False
-def bbhx_fd(ifos=None, run_phenomd=False, use_gpu=False,
-            ref_frame='LISA', sample_points=None, **params):
+def _bbhx_fd(ifos=None, run_phenomd=True, ref_frame='LISA',
+             sample_points=None, **params):
 
     if ifos is None:
         raise Exception("Must define data streams to compute")
@@ -145,8 +148,7 @@ def bbhx_fd(ifos=None, run_phenomd=False, use_gpu=False,
     # frequency. The factor of 25 ensures reasonable spacing while doing this.
     # So we round down to the nearest 1/25 of the logarithm of the frequency
     log_mf_min = int(math.log(f_min*MTSUN_SI*(m1+m2)) * 25)
-    wave_gen = get_waveform_genner(log_mf_min, run_phenomd=run_phenomd,
-                                   use_gpu=use_gpu)
+    wave_gen = get_waveform_genner(log_mf_min, run_phenomd=run_phenomd)
 
     if sample_points is None:
         if 'delta_f' in params and params['delta_f'] > 0:
@@ -177,36 +179,15 @@ def bbhx_fd(ifos=None, run_phenomd=False, use_gpu=False,
     shift_t_limits = False # Times are relative to merger
     t_obs_end = 0.0 # Generates ringdown as well!
 
-    params['modes'] = float(params['modes'])
-    if params['modes'] == 22.0:
-        modes = [(2,2)]
-    elif params['modes'] == 21.0:
-        modes = [(2,1)]
-    elif params['modes'] == 33.0:
-        modes = [(3,3)]
-    elif params['modes'] == 32.0:
-        modes = [(3,2)]
-    elif params['modes'] == 44.0:
-        modes = [(4,4)]
-    elif params['modes'] == 43.0:
-        modes = [(4,3)]
-    elif params['modes'] == 2233.0:
-        modes = [(2,2),(3,3)]
-    elif params['modes'] == 223344.0:
-        modes = [(2,2),(3,3),(4,4)]
-    elif params['modes'] == 22334443.0:
-        modes = [(2,2),(3,3),(4,4),(4,3)]
-    elif params['modes'] == 223344213243.0:
-        modes = [(2,2),(3,3),(4,4),(2,1),(3,2),(4,3)]
-
 
     # NOTE: This does not allow for the seperation of multiple modes into
-    # their own streams.
+    # their own streams. All modes requested are combined into one stream.
     wave = wave_gen(m1, m2, a1, a2,
                     dist, phi_ref, f_ref, inc, lam,
                     beta, psi, t_ref, freqs=freqs,
-                    modes=modes, direct=direct, fill=fill, squeeze=squeeze,
-                    length=length, t_obs_start=t_obs_start/YRSID_SI,
+                    modes=params['mode_array'], direct=direct, fill=fill,
+                    squeeze=squeeze, length=length,
+                    t_obs_start=t_obs_start/YRSID_SI,
                     t_obs_end=t_obs_end, compress=compress,
                     shift_t_limits=shift_t_limits)[0]
 

--- a/BBHX_Phenom.py
+++ b/BBHX_Phenom.py
@@ -135,6 +135,8 @@ please set it to be the default value %f, which will put LISA behind \
 the Earth by ~20 degrees." % TIME_OFFSET_20_DEGREES)
     t_obs_start = np.float64(params['t_obs_start']) # in seconds
     mode_array = list(params["mode_array"])
+    num_interp = int(num_interp)
+    length = int(length) if length is not None else None
 
     if ref_frame == 'LISA':
         t_ref_lisa = np.float64(params['tc']) + t_offset
@@ -230,26 +232,27 @@ the Earth by ~20 degrees." % TIME_OFFSET_20_DEGREES)
     shift_t_limits = False # Times are relative to merger
     t_obs_end = 0.0 # Generates ringdown as well!
 
-    # NOTE: This does not allow for the seperation of multiple modes into
+    # NOTE: This does not allow for the separation of multiple modes into
     # their own streams. All modes requested are combined into one stream.
-    if direct:
-        wave = wave_gen(m1, m2, a1, a2,
-                        dist, phi_ref, f_ref, inc, lam,
-                        beta, psi, t_ref, freqs=freqs,
-                        modes=mode_array, direct=True, fill=fill,
-                        squeeze=squeeze, t_obs_start=t_obs_start/YRSID_SI,
-                        t_obs_end=t_obs_end, compress=compress,
-                        shift_t_limits=shift_t_limits)
-    else:
-        # Need to give length if direct = False.
-        wave = wave_gen(m1, m2, a1, a2,
-                        dist, phi_ref, f_ref, inc, lam,
-                        beta, psi, t_ref, freqs=freqs,
-                        modes=mode_array, direct=direct, fill=fill,
-                        squeeze=squeeze, length=int(length),
-                        t_obs_start=t_obs_start/YRSID_SI,
-                        t_obs_end=t_obs_end, compress=compress,
-                        shift_t_limits=shift_t_limits)[0]
+    wave = wave_gen(
+        m1, m2, a1, a2,
+        dist, phi_ref, f_ref, inc, lam,
+        beta, psi, t_ref,
+        freqs=freqs,
+        modes=mode_array,
+        direct=direct,
+        fill=fill,
+        squeeze=squeeze,
+        t_obs_start=t_obs_start / YRSID_SI,
+        t_obs_end=t_obs_end,
+        compress=compress,
+        length=length,
+        shift_t_limits=shift_t_limits,
+    )
+    # For some reason, the shape is different depending on if direct is True
+    # or False.
+    if not direct:
+        wave = wave[0]
 
     wanted = {}
 

--- a/BBHX_Phenom.py
+++ b/BBHX_Phenom.py
@@ -94,7 +94,7 @@ def waveform_setup(**kwargs):
         kwargs['mode_array'] = [(2, 2)]
         return _bbhx_fd(run_phenomd=True, **kwargs)
     elif kwargs['approximant'] == "BBHX_PhenomHM":
-        if 'mode_array' not in kwargs:
+        if kwargs.get('mode_array') is None:
             kwargs['mode_array'] = [(2, 2), (2, 1), (3, 3), (3, 2), (4, 4), (4, 3)]
         return _bbhx_fd(run_phenomd=False, **kwargs)
     else:

--- a/BBHX_Phenom.py
+++ b/BBHX_Phenom.py
@@ -69,7 +69,7 @@ def imr_duration(**params):
     return time_length * 1.1
 
 
-def interpolated_tf(m1, m2, m_mode=None):
+def interpolated_tf(m1, m2, m_mode=None, num_interp=100):
     """Interpolate the time frequency-track.
 
     Defaults to the dominant (2,2) mode and uses :code:`chirptime` to compute
@@ -78,7 +78,7 @@ def interpolated_tf(m1, m2, m_mode=None):
     # Using findchirp_chirptime in PyCBC to calculate
     # the time-frequency track of dominant mode to get
     # the corresponding `f_min` for `t_obs_start`.
-    freq_array = np.logspace(-4, 0, num=10)
+    freq_array = np.logspace(-4, 0, num=num_interp)
     t_array = np.zeros(len(freq_array))
     t_array = chirptime(m1=m1, m2=m2, f_lower=freq_array, m_mode=m_mode)
     tf_track = interp1d(t_array, freq_array)
@@ -106,6 +106,7 @@ def _bbhx_fd(
     sample_points=None,
     length=1024,
     direct=False,
+    num_interp=100,
     **params
 ):
 
@@ -171,7 +172,9 @@ the Earth by ~20 degrees." % TIME_OFFSET_20_DEGREES)
     min_m_mode = max([mode[1] for mode in mode_array])
     if ('f_lower' not in params) or (params['f_lower'] < 0):
         # the default value of 'f_lower' in PyCBC is -1.
-        tf_track = interpolated_tf(m1, m2, m_mode=min_m_mode)
+        tf_track = interpolated_tf(
+            m1, m2, m_mode=min_m_mode, num_interp=num_interp
+        )
         t_max = chirptime(m1=m1, m2=m2, f_lower=1e-4, m_mode=min_m_mode)
         if t_obs_start > t_max:
             # Avoid "above the interpolation range" issue.
@@ -180,7 +183,9 @@ the Earth by ~20 degrees." % TIME_OFFSET_20_DEGREES)
             f_min = tf_track(t_obs_start) # in Hz
     else:
         f_min = np.float64(params['f_lower']) # in Hz
-        tf_track = interpolated_tf(m1, m2, m_mode=min_m_mode)
+        tf_track = interpolated_tf(
+            m1, m2, m_mode=min_m_mode, num_interp=num_interp
+        )
         t_max = chirptime(m1=m1, m2=m2, f_lower=1e-4, m_mode=min_m_mode)
         if t_obs_start > t_max:
             f_min_tobs = 1e-4

--- a/BBHX_Phenom.py
+++ b/BBHX_Phenom.py
@@ -70,6 +70,8 @@ def waveform_setup(**kwargs):
         kwargs['mode_array'] = [(2, 2)]
         return _bbhx_fd(**kwargs)
     elif kwargs['approximant'] == "BBHX_PhenomHM":
+        if 'mode_array' not in kwargs:
+            raise Exception("Must define modes in mode_array")
         return _bbhx_fd(run_phenomd=False, **kwargs)
 
 def _bbhx_fd(ifos=None, run_phenomd=True, ref_frame='LISA',

--- a/BBHX_Phenom.py
+++ b/BBHX_Phenom.py
@@ -93,8 +93,8 @@ def _bbhx_fd(ifos=None, run_phenomd=True, ref_frame='LISA',
             t_offset = np.float64(params['t_offset']) # in seconds
     else:
         raise Exception("Must set `t_offset`, if you don't have a preferred value, \
-please set it to be the default value %f, which will put LISA behind \
-the Earth by ~20 degrees." % TIME_OFFSET_20_DEGREES)
+                        please set it to be the default value %f, which will put LISA behind \
+                        the Earth by ~20 degrees." % TIME_OFFSET_20_DEGREES)
     t_obs_start = np.float64(params['t_obs_start']) # in seconds
 
     if ref_frame == 'LISA':
@@ -181,7 +181,7 @@ the Earth by ~20 degrees." % TIME_OFFSET_20_DEGREES)
     direct = False # If True, directly compute the waveform without interpolation. (Default: False)
     fill = True # See the BBHX documentation
     squeeze = True # See the BBHX documentation
-    length = 1024 # An internal generation parameter, not an output parameter
+    length = 1024 * 8 # An internal generation parameter, not an output parameter
     shift_t_limits = False # Times are relative to merger
     t_obs_end = 0.0 # Generates ringdown as well!
 

--- a/BBHX_Phenom.py
+++ b/BBHX_Phenom.py
@@ -94,6 +94,8 @@ def waveform_setup(**kwargs):
         if 'mode_array' not in kwargs:
             kwargs['mode_array'] = [(2, 2), (2, 1), (3, 3), (3, 2), (4, 4), (4, 3)]
         return _bbhx_fd(run_phenomd=False, **kwargs)
+    else:
+        raise ValueError(f"Invalid approximant: {kwargs['approximant']}")
 
 
 def _bbhx_fd(

--- a/BBHX_PhenomD.py
+++ b/BBHX_PhenomD.py
@@ -170,7 +170,15 @@ def bbhx_fd(ifos=None, run_phenomd=True, use_gpu=False,
     length = 1024 # An internal generation parameter, not an output parameter
     shift_t_limits = False # Times are relative to merger
     t_obs_end = 0.0 # Generates ringdown as well!
-    if not run_phenomd:
+    if run_phenomd:
+        wave = wave_gen(m1, m2, a1, a2,
+                        dist, phi_ref, f_ref, inc, lam,
+                        beta, psi, t_ref, freqs=freqs, direct=direct,
+                        fill=fill, squeeze=squeeze, length=length,
+                        t_obs_start=t_obs_start/YRSID_SI,
+                        t_obs_end=t_obs_end, compress=compress,
+                        shift_t_limits=shift_t_limits)[0]
+    else:
         modes = params['modes'] # More modes if not phenomd
         compress = False
         direct = True
@@ -181,14 +189,6 @@ def bbhx_fd(ifos=None, run_phenomd=True, use_gpu=False,
                         length=length, t_obs_start=t_obs_start/YRSID_SI,
                         t_obs_end=t_obs_end, compress=compress,
                         shift_t_limits=shift_t_limits) # Remeber that there was a [0] previously!
-    else:
-        wave = wave_gen(m1, m2, a1, a2,
-                        dist, phi_ref, f_ref, inc, lam,
-                        beta, psi, t_ref, freqs=freqs, direct=direct,
-                        fill=fill, squeeze=squeeze, length=length,
-                        t_obs_start=t_obs_start/YRSID_SI,
-                        t_obs_end=t_obs_end, compress=compress,
-                        shift_t_limits=shift_t_limits)[0]
 
 
     wanted = {}

--- a/BBHX_PhenomD.py
+++ b/BBHX_PhenomD.py
@@ -160,8 +160,13 @@ def bbhx_fd(ifos=None, run_phenomd=True,
     else:
         freqs = sample_points
 
-    modes = [(2,2)] # More modes if not phenomd
-    direct = False # See the BBHX documentation
+    compress=True
+    modes = [(2,2)]
+    direct = False
+    if not run_phenomd:
+        modes = params['modes'] # More modes if not phenomd
+        compress = False #  If True, combine harmonics into single channel waveforms. (Default: True)
+        direct = True # If True, directly compute the waveform without interpolation. (Default: False)
     fill = True # See the BBHX documentation
     squeeze = True # See the BBHX documentation
     length = 1024 # An internal generation parameter, not an output parameter
@@ -173,8 +178,9 @@ def bbhx_fd(ifos=None, run_phenomd=True,
                     beta, psi, t_ref, freqs=freqs,
                     modes=modes, direct=direct, fill=fill, squeeze=squeeze,
                     length=length, t_obs_start=t_obs_start/YRSID_SI,
-                    t_obs_end=t_obs_end,
-                    shift_t_limits=shift_t_limits)[0]
+                    t_obs_end=t_obs_end, compress=compress,
+                    shift_t_limits=shift_t_limits) # Remeber that there was a [0] previously!
+
 
     wanted = {}
 

--- a/BBHX_PhenomD.py
+++ b/BBHX_PhenomD.py
@@ -163,14 +163,20 @@ def bbhx_fd(ifos=None, run_phenomd=True, use_gpu=False,
     else:
         freqs = sample_points
 
-    compress=True #  If True, combine harmonics into single channel waveforms. (Default: True)
+    # If creating injection of many modes, or just single, compress = True
+    # will do the same thing.
+    compress = True #  If True, combine harmonics into single channel waveforms. (Default: True)
+    # Need to give length if direct = False.
     direct = False # If True, directly compute the waveform without interpolation. (Default: False)
     fill = True # See the BBHX documentation
     squeeze = True # See the BBHX documentation
     length = 1024 # An internal generation parameter, not an output parameter
     shift_t_limits = False # Times are relative to merger
     t_obs_end = 0.0 # Generates ringdown as well!
+    modes = params['modes'] # More modes if not phenomd
+
     if run_phenomd:
+        # Of run_phenomd, modes is automatically set to (2,2).
         wave = wave_gen(m1, m2, a1, a2,
                         dist, phi_ref, f_ref, inc, lam,
                         beta, psi, t_ref, freqs=freqs, direct=direct,
@@ -179,17 +185,19 @@ def bbhx_fd(ifos=None, run_phenomd=True, use_gpu=False,
                         t_obs_end=t_obs_end, compress=compress,
                         shift_t_limits=shift_t_limits)[0]
     else:
+        # This should work with both generating entire injections with
+        # multiple modes and when computing single modes for inference.
+        # This will NOT work when wanting the mode information seperately.
+        # If you want all modes seperated out, the final [0] needs to be
+        # removed as that is the A TDI stream.
         modes = params['modes'] # More modes if not phenomd
-        compress = False
-        direct = True
         wave = wave_gen(m1, m2, a1, a2,
                         dist, phi_ref, f_ref, inc, lam,
                         beta, psi, t_ref, freqs=freqs,
                         modes=modes, direct=direct, fill=fill, squeeze=squeeze,
                         length=length, t_obs_start=t_obs_start/YRSID_SI,
                         t_obs_end=t_obs_end, compress=compress,
-                        shift_t_limits=shift_t_limits) # Remeber that there was a [0] previously!
-
+                        shift_t_limits=shift_t_limits)[0]
 
     wanted = {}
 

--- a/BBHX_PhenomD.py
+++ b/BBHX_PhenomD.py
@@ -57,15 +57,18 @@ def interpolated_tf(m1, m2):
     tf_track = interp1d(t_array, freq_array)
     return tf_track
 
-def bbhx_fd(ifos=None, run_phenomd=True, use_gpu=False,
+
+
+# For now, always run phenom=False
+def bbhx_fd(ifos=None, run_phenomd=False, use_gpu=False,
             ref_frame='LISA', sample_points=None, **params):
 
     if ifos is None:
         raise Exception("Must define data streams to compute")
 
     # If asking for anything but the (2,2) mode, run PhenomHM
-    if params['modes'] != [(2, 2)]:
-        run_phenomd = False
+    # if params['modes'] != [(2, 2)]:
+    #     run_phenomd = False
 
     from pycbc.types import FrequencySeries, Array
     from pycbc import pnutils
@@ -166,6 +169,11 @@ def bbhx_fd(ifos=None, run_phenomd=True, use_gpu=False,
             raise Exception("Please set 'f_final' in **params.")
     else:
         freqs = sample_points
+
+    if params['modes'] == 22.0:
+        params['modes'] = [(2,2)]
+    elif params['modes'] == 33.0:
+        params['modes'] = [(3,3)]
 
     # If creating injection of many modes, or just single, compress = True
     # will do the same thing.

--- a/BBHX_PhenomD.py
+++ b/BBHX_PhenomD.py
@@ -63,6 +63,10 @@ def bbhx_fd(ifos=None, run_phenomd=True, use_gpu=False,
     if ifos is None:
         raise Exception("Must define data streams to compute")
 
+    # If asking for anything but the (2,2) mode, run PhenomHM
+    if params['modes'] != [(2, 2)]:
+        run_phenomd = False
+
     from pycbc.types import FrequencySeries, Array
     from pycbc import pnutils
 
@@ -175,29 +179,16 @@ def bbhx_fd(ifos=None, run_phenomd=True, use_gpu=False,
     t_obs_end = 0.0 # Generates ringdown as well!
     modes = params['modes'] # More modes if not phenomd
 
-    if run_phenomd:
-        # Of run_phenomd, modes is automatically set to (2,2).
-        wave = wave_gen(m1, m2, a1, a2,
-                        dist, phi_ref, f_ref, inc, lam,
-                        beta, psi, t_ref, freqs=freqs, direct=direct,
-                        fill=fill, squeeze=squeeze, length=length,
-                        t_obs_start=t_obs_start/YRSID_SI,
-                        t_obs_end=t_obs_end, compress=compress,
-                        shift_t_limits=shift_t_limits)[0]
-    else:
-        # This should work with both generating entire injections with
-        # multiple modes and when computing single modes for inference.
-        # This will NOT work when wanting the mode information seperately.
-        # If you want all modes seperated out, the final [0] needs to be
-        # removed as that is the A TDI stream.
-        modes = params['modes'] # More modes if not phenomd
-        wave = wave_gen(m1, m2, a1, a2,
-                        dist, phi_ref, f_ref, inc, lam,
-                        beta, psi, t_ref, freqs=freqs,
-                        modes=modes, direct=direct, fill=fill, squeeze=squeeze,
-                        length=length, t_obs_start=t_obs_start/YRSID_SI,
-                        t_obs_end=t_obs_end, compress=compress,
-                        shift_t_limits=shift_t_limits)[0]
+
+    # NOTE: This does not allow for the seperation of multiple modes into
+    # their own streams.
+    wave = wave_gen(m1, m2, a1, a2,
+                    dist, phi_ref, f_ref, inc, lam,
+                    beta, psi, t_ref, freqs=freqs,
+                    modes=modes, direct=direct, fill=fill, squeeze=squeeze,
+                    length=length, t_obs_start=t_obs_start/YRSID_SI,
+                    t_obs_end=t_obs_end, compress=compress,
+                    shift_t_limits=shift_t_limits)[0]
 
     wanted = {}
 

--- a/BBHX_PhenomD.py
+++ b/BBHX_PhenomD.py
@@ -8,11 +8,13 @@ from pycbc.coordinates import TIME_OFFSET_20_DEGREES, lisa_to_ssb, ssb_to_lisa
 
 
 @functools.lru_cache(maxsize=128)
-def get_waveform_genner(log_mf_min, run_phenomd=True):
+def get_waveform_genner(log_mf_min, run_phenomd=True, use_gpu=False):
     # See below where this function is called for description of how we handle
     # log_mf_min.
     mf_min = math.exp(log_mf_min/25.)
-    wave_gen = BBHWaveformFD(amp_phase_kwargs=dict(run_phenomd=run_phenomd, mf_min=mf_min))
+    wave_gen = BBHWaveformFD(amp_phase_kwargs=dict(run_phenomd=run_phenomd,
+                                                   mf_min=mf_min),
+                             use_gpu=use_gpu)
     return wave_gen
 
 @functools.lru_cache(maxsize=10)
@@ -45,7 +47,7 @@ def imr_duration(**params):
     return time_length * 1.1
 
 def interpolated_tf(m1, m2):
-    # Using findchirp_chirptime in PyCBC to calculate 
+    # Using findchirp_chirptime in PyCBC to calculate
     # the time-frequency track of dominant mode to get
     # the corresponding `f_min` for `t_obs_start`.
     freq_array = np.logspace(-4, 0, num=10)
@@ -55,7 +57,7 @@ def interpolated_tf(m1, m2):
     tf_track = interp1d(t_array, freq_array)
     return tf_track
 
-def bbhx_fd(ifos=None, run_phenomd=True,
+def bbhx_fd(ifos=None, run_phenomd=True, use_gpu=False,
             ref_frame='LISA', sample_points=None, **params):
 
     if ifos is None:
@@ -140,7 +142,8 @@ def bbhx_fd(ifos=None, run_phenomd=True,
     # frequency. The factor of 25 ensures reasonable spacing while doing this.
     # So we round down to the nearest 1/25 of the logarithm of the frequency
     log_mf_min = int(math.log(f_min*MTSUN_SI*(m1+m2)) * 25)
-    wave_gen = get_waveform_genner(log_mf_min, run_phenomd=run_phenomd)
+    wave_gen = get_waveform_genner(log_mf_min, run_phenomd=run_phenomd,
+                                   use_gpu=use_gpu)
 
     if sample_points is None:
         if 'delta_f' in params and params['delta_f'] > 0:

--- a/BBHX_PhenomD.py
+++ b/BBHX_PhenomD.py
@@ -166,14 +166,6 @@ def bbhx_fd(ifos=None, run_phenomd=False, use_gpu=False,
     else:
         freqs = sample_points
 
-    #freqs = np.load('/home/connor/main/higher_modes_dev/likelihood_testing/freq.npy')
-    print(freqs)
-
-    if params['modes'] == 22.0:
-        params['modes'] = [(2,2)]
-    elif params['modes'] == 33.0:
-        params['modes'] = [(3,3)]
-
     # If creating injection of many modes, or just single, compress = True
     # will do the same thing.
     compress = True #  If True, combine harmonics into single channel waveforms. (Default: True)
@@ -184,8 +176,20 @@ def bbhx_fd(ifos=None, run_phenomd=False, use_gpu=False,
     length = 1024 # An internal generation parameter, not an output parameter
     shift_t_limits = False # Times are relative to merger
     t_obs_end = 0.0 # Generates ringdown as well!
-    modes = params['modes'] # More modes if not phenomd
+    # modes = params['modes'] # More modes if not phenomd
 
+    params['modes'] = float(params['modes'])
+
+    if params['modes'] == 22.0:
+        modes = [(2,2)]
+    elif params['modes'] == 33.0:
+        modes = [(3,3)]
+    elif params['modes'] == 44.0:
+        modes = [(4,4)]
+    elif params['modes'] == 2233.0:
+        modes = [(2,2),(3,3)]
+    elif params['modes'] == 223344.0:
+        modes = [(2,2),(3,3),(4,4)]
 
     # NOTE: This does not allow for the seperation of multiple modes into
     # their own streams.

--- a/BBHX_PhenomD.py
+++ b/BBHX_PhenomD.py
@@ -176,20 +176,29 @@ def bbhx_fd(ifos=None, run_phenomd=False, use_gpu=False,
     length = 1024 # An internal generation parameter, not an output parameter
     shift_t_limits = False # Times are relative to merger
     t_obs_end = 0.0 # Generates ringdown as well!
-    # modes = params['modes'] # More modes if not phenomd
 
     params['modes'] = float(params['modes'])
-
     if params['modes'] == 22.0:
         modes = [(2,2)]
+    elif params['modes'] == 21.0:
+        modes = [(2,1)]
     elif params['modes'] == 33.0:
         modes = [(3,3)]
+    elif params['modes'] == 32.0:
+        modes = [(3,2)]
     elif params['modes'] == 44.0:
         modes = [(4,4)]
+    elif params['modes'] == 43.0:
+        modes = [(4,3)]
     elif params['modes'] == 2233.0:
         modes = [(2,2),(3,3)]
     elif params['modes'] == 223344.0:
         modes = [(2,2),(3,3),(4,4)]
+    elif params['modes'] == 22334443.0:
+        modes = [(2,2),(3,3),(4,4),(4,3)]
+    elif params['modes'] == 223344213243.0:
+        modes = [(2,2),(3,3),(4,4),(2,1),(3,2),(4,3)]
+
 
     # NOTE: This does not allow for the seperation of multiple modes into
     # their own streams.

--- a/BBHX_PhenomD.py
+++ b/BBHX_PhenomD.py
@@ -163,26 +163,32 @@ def bbhx_fd(ifos=None, run_phenomd=True, use_gpu=False,
     else:
         freqs = sample_points
 
-    compress=True
-    modes = [(2,2)]
-    direct = False
-    if not run_phenomd:
-        modes = params['modes'] # More modes if not phenomd
-        compress = False #  If True, combine harmonics into single channel waveforms. (Default: True)
-        direct = True # If True, directly compute the waveform without interpolation. (Default: False)
+    compress=True #  If True, combine harmonics into single channel waveforms. (Default: True)
+    direct = False # If True, directly compute the waveform without interpolation. (Default: False)
     fill = True # See the BBHX documentation
     squeeze = True # See the BBHX documentation
     length = 1024 # An internal generation parameter, not an output parameter
     shift_t_limits = False # Times are relative to merger
     t_obs_end = 0.0 # Generates ringdown as well!
-
-    wave = wave_gen(m1, m2, a1, a2,
-                    dist, phi_ref, f_ref, inc, lam,
-                    beta, psi, t_ref, freqs=freqs,
-                    modes=modes, direct=direct, fill=fill, squeeze=squeeze,
-                    length=length, t_obs_start=t_obs_start/YRSID_SI,
-                    t_obs_end=t_obs_end, compress=compress,
-                    shift_t_limits=shift_t_limits) # Remeber that there was a [0] previously!
+    if not run_phenomd:
+        modes = params['modes'] # More modes if not phenomd
+        compress = False
+        direct = True
+        wave = wave_gen(m1, m2, a1, a2,
+                        dist, phi_ref, f_ref, inc, lam,
+                        beta, psi, t_ref, freqs=freqs,
+                        modes=modes, direct=direct, fill=fill, squeeze=squeeze,
+                        length=length, t_obs_start=t_obs_start/YRSID_SI,
+                        t_obs_end=t_obs_end, compress=compress,
+                        shift_t_limits=shift_t_limits) # Remeber that there was a [0] previously!
+    else:
+        wave = wave_gen(m1, m2, a1, a2,
+                        dist, phi_ref, f_ref, inc, lam,
+                        beta, psi, t_ref, freqs=freqs, direct=direct,
+                        fill=fill, squeeze=squeeze, length=length,
+                        t_obs_start=t_obs_start/YRSID_SI,
+                        t_obs_end=t_obs_end, compress=compress,
+                        shift_t_limits=shift_t_limits)[0]
 
 
     wanted = {}

--- a/BBHX_PhenomD.py
+++ b/BBHX_PhenomD.py
@@ -170,6 +170,8 @@ def bbhx_fd(ifos=None, run_phenomd=False, use_gpu=False,
     else:
         freqs = sample_points
 
+    # freqs = np.load('/home/connor/main/higher_modes_dev/likelihood_testing/freq.npy')
+
     if params['modes'] == 22.0:
         params['modes'] = [(2,2)]
     elif params['modes'] == 33.0:

--- a/BBHX_PhenomD.py
+++ b/BBHX_PhenomD.py
@@ -66,10 +66,6 @@ def bbhx_fd(ifos=None, run_phenomd=False, use_gpu=False,
     if ifos is None:
         raise Exception("Must define data streams to compute")
 
-    # If asking for anything but the (2,2) mode, run PhenomHM
-    # if params['modes'] != [(2, 2)]:
-    #     run_phenomd = False
-
     from pycbc.types import FrequencySeries, Array
     from pycbc import pnutils
 
@@ -170,7 +166,8 @@ def bbhx_fd(ifos=None, run_phenomd=False, use_gpu=False,
     else:
         freqs = sample_points
 
-    # freqs = np.load('/home/connor/main/higher_modes_dev/likelihood_testing/freq.npy')
+    #freqs = np.load('/home/connor/main/higher_modes_dev/likelihood_testing/freq.npy')
+    print(freqs)
 
     if params['modes'] == 22.0:
         params['modes'] = [(2,2)]

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,20 @@ setup (
     keywords = ['pycbc', 'signal processing', 'gravitational waves', 'lisa'],
     install_requires = ['pycbc'],
     py_modules = ['BBHX_Phenom'],
-    entry_points = {"pycbc.waveform.fd_det":["BBHX_PhenomD=BBHX_Phenom:waveform_setup", "BBHX_PhenomHM=BBHX_Phenom:waveform_setup"],
-                    "pycbc.waveform.fd_det_sequence":["BBHX_PhenomD=BBHX_Phenom:waveform_setup", "BBHX_PhenomHM=BBHX_Phenom:waveform_setup"],
-                    "pycbc.waveform.length":"BBHX_PhenomD=BBHX_Phenom:imr_duration"},
+    entry_points = {
+        "pycbc.waveform.fd_det":[
+            "BBHX_PhenomD=BBHX_Phenom:waveform_setup",
+            "BBHX_PhenomHM=BBHX_Phenom:waveform_setup",
+        ],
+        "pycbc.waveform.fd_det_sequence": [
+            "BBHX_PhenomD=BBHX_Phenom:waveform_setup",
+            "BBHX_PhenomHM=BBHX_Phenom:waveform_setup",
+        ],
+        "pycbc.waveform.length": [
+            "BBHX_PhenomD=BBHX_Phenom:imr_duration",
+            "BBHX_PhenomHM=BBHX_Phenom:imr_duration",
+        ]
+    },
 
     classifiers=[
         'Programming Language :: Python',

--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,10 @@ setup (
     download_url = 'https://github.com/gwastro/BBHX-waveform-model/v%s' % VERSION,
     keywords = ['pycbc', 'signal processing', 'gravitational waves', 'lisa'],
     install_requires = ['pycbc'],
-    py_modules = ['BBHX_PhenomD'],
-    entry_points = {"pycbc.waveform.fd_det":"BBHX_PhenomD=BBHX_PhenomD:bbhx_fd",
-                    "pycbc.waveform.fd_det_sequence":"BBHX_PhenomD=BBHX_PhenomD:bbhx_fd",
-                    "pycbc.waveform.length":"BBHX_PhenomD=BBHX_PhenomD:imr_duration"},
+    py_modules = ['BBHX_Phenom'],
+    entry_points = {"pycbc.waveform.fd_det":["BBHX_PhenomD=BBHX_Phenom:waveform_setup", "BBHX_PhenomHM=BBHX_Phenom:waveform_setup"],
+                    "pycbc.waveform.fd_det_sequence":["BBHX_PhenomD=BBHX_Phenom:waveform_setup", "BBHX_PhenomHM=BBHX_Phenom:waveform_setup"],
+                    "pycbc.waveform.length":"BBHX_PhenomD=BBHX_Phenom:imr_duration"},
 
     classifiers=[
         'Programming Language :: Python',

--- a/tests.py
+++ b/tests.py
@@ -13,6 +13,11 @@ def ref_frame(request):
     return request.param
 
 
+@pytest.fixture(params=["1.5", "2.0"])
+def tdi(request):
+    return request.param
+
+
 @pytest.fixture()
 def params():
     params = {}
@@ -41,7 +46,6 @@ def params():
     return params
 
 
-@pytest.mark.parametrize("tdi", ["1.5", "2.0"])
 def test_get_fd_det_waveform(params, ref_frame, approximant, tdi):
     params["tdi"] = tdi
     params["ref_frame"] = ref_frame
@@ -51,8 +55,9 @@ def test_get_fd_det_waveform(params, ref_frame, approximant, tdi):
     assert len(wf) == 3
 
 
-def test_get_fd_det_waveform_sequence(params, approximant):
+def test_get_fd_det_waveform_sequence(params, approximant, tdi):
     params["ifos"] = "LISA_A"
+    params["tdi"] = tdi
     params["approximant"] = approximant
     freqs = np.array([1-4, 1e-3, 1e-2])
     wf = get_fd_det_waveform_sequence(sample_points=freqs, **params)


### PR DESCRIPTION
Add support for HoM.

This MR supersedes https://github.com/gwastro/BBHX-waveform-model/pull/2, since Connor is writing up and I'm going to try and get this change in for the various projects that need it.

## Summary of changes

- Original changes from Connor's PR
- Add `m_mode` keyword argument to `chirptime` and `interpolate_tf` 
- Allow user to set the number of interpolation points `num_interp`

## To-Do

- [x] Plots described in https://github.com/ConWea/BBHX-waveform-model/pull/2