### PR TITLE
Add lalsuite to mamba env

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,7 @@ jobs:
           gxx_linux-64
           gsl
           lapack=3.6.1
+          lalsuite
           numpy
           scipy
           cython


### PR DESCRIPTION
I noticed that the CI is installing lalsuite with pip, this slows things down since the pip dependencies are not cached. To avoid this, I've added lalsuite to the mamba env.