### PR TITLE
Add test for get filter length

### DIFF
--- a/BBHX_Phenom.py
+++ b/BBHX_Phenom.py
@@ -55,13 +55,14 @@ def imr_duration(**params):
     nparams = {'mass1':params['mass1'], 'mass2':params['mass2'],
                'spin1z':params['spin1z'], 'spin2z':params['spin2z'],
                'f_lower':params['f_lower']}
-
     if params['approximant'] == 'BBHX_PhenomD':
         from pycbc.waveform.waveform import imrphenomd_length_in_time
         time_length = np.float64(imrphenomd_length_in_time(**nparams))
     elif params['approximant'] == 'BBHX_PhenomHM':
         from pycbc.waveform.waveform import imrphenomhm_length_in_time
         time_length = np.float64(imrphenomhm_length_in_time(**nparams))
+    else:
+        raise ValueError(f"Invalid approximant: {params['approximant']}")
 
     if time_length < 2678400:
         warnings.warn("Waveform duration is too short! Setting it to 1 month (2678400 s).")

--- a/tests.py
+++ b/tests.py
@@ -1,5 +1,9 @@
 import numpy as np
-from pycbc.waveform import get_fd_det_waveform, get_fd_det_waveform_sequence
+from pycbc.waveform import (
+    get_fd_det_waveform,
+    get_fd_det_waveform_sequence,
+    get_waveform_filter_length_in_time,
+)
 import pytest
 
 
@@ -72,3 +76,10 @@ def test_phenomhm_mode_array(params, mode_array):
     params["mode_array"] = mode_array
     wf = get_fd_det_waveform(**params)
     assert len(wf) == 3
+
+
+def test_length_in_time(params, approximant):
+    params["approximant"] = approximant
+    # print(params)
+    duration = get_waveform_filter_length_in_time(**params)
+    assert duration > 0


### PR DESCRIPTION
I've added a test for the `get_waveform_filter_length_in_time`.

It seems this doesn't work, since this test is failing, so this might need fixing.