### PR TITLE
Add option to specify `mf_min`

### DIFF
--- a/BBHX_Phenom.py
+++ b/BBHX_Phenom.py
@@ -354,7 +354,7 @@ the Earth by ~20 degrees." % TIME_OFFSET_20_DEGREES)
     # or False.
     if not direct:
         wave = wave[0]
-    
+
     wanted = {}
 
     if 'LISA_A' in ifos:


### PR DESCRIPTION
This PR adds the `mf_min` option to the plugin which is in turn passed to `BBHx`. When specified, all the caching in the plugin is skipped. This will be slower but should avoid any issues arising from using different ranges for interpolation.

I'm still testing this and I'll provide updates once I have some results.